### PR TITLE
feat: Add new tools for Sentinel incident management

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -5,20 +5,59 @@ mcp = FastMCP("Sentinel-MCP", log_level="INFO")
 
 
 @mcp.tool(
+    name="run_kql_query",
+    description="Execute a KQL query against the Sentinel Log Analytics workspace. Returns rows as JSON objects. Example query: 'SecurityIncident | take 5'.",
+)
+def run_kql(query: str):
+    return sentinel_client.run_kql_query(query)
+
+
+@mcp.tool(
     name="get_incidents",
     description="Fetches Sentinel incidents. Returns a list of incidents with title, severity, status, and description.",
 )
 def get_incidents():
-    incidents = sentinel_client.get_sentinel_incidents()
-    return incidents
+    return sentinel_client.get_sentinel_incidents()
 
 
 @mcp.tool(
-    name="run_kql_query",
-    description="Execute a KQL query against the Sentinel Log Analytics workspace. Returns rows as JSON objects. Example query: 'SecurityIncident | take 5'.",
+    name="get_incident_by_id",
+    description="Fetches a single Sentinel incident by its ID.",
 )
-def run_kql_tool(query: str):
-    return sentinel_client.run_kql_query(query)
+def get_incident_by_id(incident_id: str):
+    return sentinel_client.get_incident_by_id(incident_id)
+
+
+@mcp.tool(
+    name="update_incident",
+    description="Updates an existing incident. Allows modifying status, severity, and owner.",
+)
+def update_incident(incident_id: str, status: str = None, severity: str = None, owner: dict = None):
+    return sentinel_client.update_incident(incident_id, status, severity, owner)
+
+
+@mcp.tool(
+    name="get_incident_comments",
+    description="Retrieves all comments for a given incident.",
+)
+def get_incident_comments(incident_id: str):
+    return sentinel_client.get_incident_comments(incident_id)
+
+
+@mcp.tool(
+    name="add_incident_comment",
+    description="Adds a comment to a specific incident.",
+)
+def add_incident_comment(incident_id: str, message: str):
+    return sentinel_client.add_incident_comment(incident_id, message)
+
+
+@mcp.tool(
+    name="get_incident_alerts",
+    description="Gets all alerts for a given incident.",
+)
+def get_incident_alerts(incident_id: str):
+    return sentinel_client.get_incident_alerts(incident_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_sentinel_client.py
+++ b/tests/test_sentinel_client.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import uuid
 from unittest.mock import patch, MagicMock
 from src import sentinel_client
 
@@ -90,6 +91,190 @@ class TestSentinelClient(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], {'col1': 'val1', 'col2': 'val2'})
         mock_client_instance.query_workspace.assert_called_with(workspace_id=os.getenv("AZURE_WORKSPACE_ID", ""), query=query, timespan=None)
+
+    @patch('src.sentinel_client.get_credentials')
+    @patch('requests.get')
+    def test_get_incident_by_id(self, mock_requests_get, mock_get_credentials):
+        # Mock credentials and token
+        mock_credential = MagicMock()
+        mock_credential.get_token.return_value.token = "fake_token"
+        mock_get_credentials.return_value = mock_credential
+
+        # Mock response from requests.get
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "incident123",
+            "properties": {
+                "title": "Specific Test Incident",
+                "status": "Active",
+                "severity": "Medium",
+            }
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_requests_get.return_value = mock_response
+
+        # Call the function
+        incident = sentinel_client.get_incident_by_id("incident123")
+
+        # Assertions
+        self.assertEqual(incident['title'], "Specific Test Incident")
+        self.assertEqual(incident['status'], "Active")
+        mock_requests_get.assert_called_once()
+
+    @patch('src.sentinel_client.get_credentials')
+    @patch('requests.get')
+    def test_get_incident_comments(self, mock_requests_get, mock_get_credentials):
+        # Mock credentials and token
+        mock_credential = MagicMock()
+        mock_credential.get_token.return_value.token = "fake_token"
+        mock_get_credentials.return_value = mock_credential
+
+        # Mock response from requests.get
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "value": [
+                {
+                    "name": "comment1",
+                    "properties": {
+                        "message": "This is a test comment.",
+                        "author": {"name": "Jules"},
+                    }
+                }
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_requests_get.return_value = mock_response
+
+        # Call the function
+        comments = sentinel_client.get_incident_comments("incident123")
+
+        # Assertions
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0]['message'], "This is a test comment.")
+        self.assertEqual(comments[0]['author'], "Jules")
+        mock_requests_get.assert_called_once()
+
+    @patch('src.sentinel_client.get_credentials')
+    @patch('requests.put')
+    @patch('requests.get')
+    def test_update_incident(self, mock_requests_get, mock_requests_put, mock_get_credentials):
+        # Mock credentials and token
+        mock_credential = MagicMock()
+        mock_credential.get_token.return_value.token = "fake_token"
+        mock_get_credentials.return_value = mock_credential
+
+        # Mock GET response (for ETag)
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {
+            "name": "incident123",
+            "etag": "\"12345\"",
+            "properties": {
+                "title": "Initial Title",
+                "status": "New",
+                "severity": "Low",
+            }
+        }
+        mock_get_response.raise_for_status.return_value = None
+        mock_requests_get.return_value = mock_get_response
+
+        # Mock PUT response
+        mock_put_response = MagicMock()
+        mock_put_response.json.return_value = {
+            "name": "incident123",
+            "properties": {
+                "title": "Initial Title",
+                "status": "Active",
+                "severity": "High",
+            }
+        }
+        mock_put_response.raise_for_status.return_value = None
+        mock_requests_put.return_value = mock_put_response
+
+        # Call the function
+        updated_incident = sentinel_client.update_incident("incident123", status="Active", severity="High")
+
+        # Assertions
+        mock_requests_get.assert_called_once()
+        mock_requests_put.assert_called_once()
+
+        # Check that the ETag was correctly passed in the headers of the PUT request
+        headers = mock_requests_put.call_args.kwargs.get('headers')
+        self.assertEqual(headers['If-Match'], '"12345"')
+
+        # Check that the payload was correct
+        payload = mock_requests_put.call_args.kwargs.get('json')
+        self.assertEqual(payload['properties']['status'], 'Active')
+        self.assertEqual(payload['properties']['severity'], 'High')
+
+        # Check the final output
+        self.assertEqual(updated_incident['properties']['status'], "Active")
+
+    @patch('src.sentinel_client.get_credentials')
+    @patch('requests.put')
+    @patch('uuid.uuid4')
+    def test_add_incident_comment(self, mock_uuid, mock_requests_put, mock_get_credentials):
+        # Mock credentials and token
+        mock_credential = MagicMock()
+        mock_credential.get_token.return_value.token = "fake_token"
+        mock_get_credentials.return_value = mock_credential
+
+        # Mock uuid
+        mock_uuid.return_value = "comment-uuid"
+
+        # Mock PUT response
+        mock_put_response = MagicMock()
+        mock_put_response.json.return_value = {
+            "name": "comment-uuid",
+            "properties": {
+                "message": "This is a new comment.",
+            }
+        }
+        mock_put_response.raise_for_status.return_value = None
+        mock_requests_put.return_value = mock_put_response
+
+        # Call the function
+        new_comment = sentinel_client.add_incident_comment("incident123", "This is a new comment.")
+
+        # Assertions
+        mock_requests_put.assert_called_once()
+
+        # Check the URL contains the mocked uuid
+        self.assertIn("comment-uuid", mock_requests_put.call_args[0][0])
+
+        # Check that the payload was correct
+        payload = mock_requests_put.call_args.kwargs.get('json')
+        self.assertEqual(payload['properties']['message'], 'This is a new comment.')
+
+        # Check the final output
+        self.assertEqual(new_comment['properties']['message'], "This is a new comment.")
+
+    @patch('src.sentinel_client.get_credentials')
+    @patch('requests.post')
+    def test_get_incident_alerts(self, mock_requests_post, mock_get_credentials):
+        # Mock credentials and token
+        mock_credential = MagicMock()
+        mock_credential.get_token.return_value.token = "fake_token"
+        mock_get_credentials.return_value = mock_credential
+
+        # Mock POST response
+        mock_post_response = MagicMock()
+        mock_post_response.json.return_value = {
+            "value": [
+                {"name": "alert1", "properties": {"displayName": "Test Alert 1"}},
+                {"name": "alert2", "properties": {"displayName": "Test Alert 2"}},
+            ]
+        }
+        mock_post_response.raise_for_status.return_value = None
+        mock_requests_post.return_value = mock_post_response
+
+        # Call the function
+        alerts = sentinel_client.get_incident_alerts("incident123")
+
+        # Assertions
+        mock_requests_post.assert_called_once()
+        self.assertEqual(len(alerts), 2)
+        self.assertEqual(alerts[0]['properties']['displayName'], "Test Alert 1")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit introduces several new tools to enhance the incident management capabilities of the Sentinel MCP server.

The following tools have been added:
- `get_incident_by_id`: Fetches the complete details of a single incident.
- `update_incident`: Modifies an existing incident, allowing changes to its status, severity, and owner. This implementation correctly handles concurrency by using the incident's ETag.
- `get_incident_comments`: Retrieves all comments associated with a specific incident.
- `add_incident_comment`: Adds a new comment to an incident.
- `get_incident_alerts`: Gets all alerts for a given incident.

The functions in `sentinel_client.py` and `mcp_server.py` have been reordered for better logical grouping, and the tool-defining functions in `mcp_server.py` have been renamed for consistency.

All unit tests have been consolidated into a single file, `tests/test_sentinel_client.py`, and all tests pass.